### PR TITLE
feat: add TxnExplorerLink component for direct Solana Explorer links

### DIFF
--- a/components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx
+++ b/components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type React from "react";
+import { ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface TxnExplorerLinkProps {
+  signature: string;
+  cluster?: "mainnet-beta" | "testnet" | "devnet";
+  children?: React.ReactNode;
+  className?: string;
+  variant?:
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost"
+    | "link";
+  size?: "default" | "sm" | "lg" | "icon";
+  showIcon?: boolean;
+}
+
+export function TxnExplorerLink({
+  signature,
+  cluster = "mainnet-beta",
+  children,
+  className,
+  variant = "outline",
+  size = "sm",
+  showIcon = true,
+}: TxnExplorerLinkProps) {
+  const getExplorerUrl = () => {
+    const baseUrl = "https://explorer.solana.com/tx";
+    const clusterParam =
+      cluster !== "mainnet-beta" ? `?cluster=${cluster}` : "";
+    return `${baseUrl}/${signature}${clusterParam}`;
+  };
+
+  const handleClick = () => {
+    window.open(getExplorerUrl(), "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <Button
+      onClick={handleClick}
+      variant={variant}
+      size={size}
+      className={cn("cursor-pointer hover:underline", className)}
+    >
+      {children || (
+        <>
+          View on Explorer
+          {showIcon && (
+            <ExternalLink className="w-4 h-4 ml-2 text-muted-foreground" />
+          )}
+        </>
+      )}
+    </Button>
+  );
+}

--- a/components/ui/murphy/index.tsx
+++ b/components/ui/murphy/index.tsx
@@ -14,7 +14,7 @@ import CandyMachineForm from "./candy-machine-form";
 import CoreCandyMachineForm from "./core-candy-machine-form";
 import BubblegumLegacyForm from "./bubblegum-legacy-form";
 import ImprovedCNFTManager from "./improved-cnft-manager";
-import CompressedNFTViewer from "./compressed-nft-viewer"
+import CompressedNFTViewer from "./compressed-nft-viewer";
 import { CreateMerkleTree } from "./create-merkleTree-form";
 import { TokenList } from "./token-list";
 import { StakeForm } from "./stake-token-form";
@@ -37,6 +37,7 @@ import { CoreAssetLaunchpad } from "./core-asset-launchpad";
 import { HydraFanoutForm } from "./hydra-fanout-form";
 import { MPLHybridForm } from "./mpl-hybrid-form";
 import { TokenMetadataViewer } from "./token-metadata-viewer";
+import { TxnExplorerLink } from "./Txn-Feedback/txn-explorer-link";
 
 export {
   ConnectWalletButton,
@@ -78,5 +79,6 @@ export {
   TMLaunchpadForm,
   HydraFanoutForm,
   MPLHybridForm,
-  TokenMetadataViewer
+  TokenMetadataViewer,
+  TxnExplorerLink,
 };

--- a/content/docs/onchainkit/Txn-Feedback/txn-explorer-link.mdx
+++ b/content/docs/onchainkit/Txn-Feedback/txn-explorer-link.mdx
@@ -1,0 +1,287 @@
+---
+title: Transaction Explorer Link
+description: Direct links to Solana Explorer for transaction details
+icon: ExternalLink
+---
+
+<PreviewComponent
+  name={"Transaction Explorer Link"}
+  v0JsonFileName={"txn-explorer-link"}
+>
+  <TxnExplorerLink
+    signature="5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM7n"
+    size="lg"
+    variant="secondary"
+  />
+</PreviewComponent>
+
+## Installation
+
+<Steps>
+ 
+<Step>
+  Install Transaction Explorer Link
+  <InstallationCommands
+    packageUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/r/tx-explorer-link.json`}
+  />
+</Step>
+
+</Steps>
+
+## Basic Usage
+
+```tsx
+"use client";
+
+import { TxnExplorerLink } from "@/components/ui/murphy/Txn-Feedback/txn-explorer-link";
+
+export default function MyPage() {
+  const transactionSignature =
+    "5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM7n";
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Transaction Details</h1>
+
+      <div className="space-y-4">
+        <p>Transaction completed successfully!</p>
+
+        <TxnExplorerLink
+          signature={transactionSignature}
+          cluster="mainnet-beta"
+        >
+          View on Solana Explorer
+        </TxnExplorerLink>
+      </div>
+    </div>
+  );
+}
+```
+
+## Props
+
+<TypeTable
+  type={{
+    signature: {
+      description: "Transaction signature to link to",
+      type: "string",
+      default: "required",
+    },
+    cluster: {
+      description: "Solana cluster/network",
+      type: "'mainnet-beta' | 'testnet' | 'devnet'",
+      default: "'mainnet-beta'",
+    },
+    children: {
+      description: "Custom button content",
+      type: "React.ReactNode",
+      default: "'View on Explorer'",
+    },
+    className: {
+      description: "Additional CSS classes",
+      type: "string",
+      default: "undefined",
+    },
+    variant: {
+      description: "Button variant style",
+      type: "'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'",
+      default: "'outline'",
+    },
+    size: {
+      description: "Button size",
+      type: "'default' | 'sm' | 'lg' | 'icon'",
+      default: "'sm'",
+    },
+    showIcon: {
+      description: "Whether to show the external link icon",
+      type: "boolean",
+      default: "true",
+    },
+  }}
+/>
+
+## Examples
+
+### Different Clusters
+
+```tsx
+// Mainnet transaction
+
+<TxnExplorerLink
+  signature="5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM7n"
+  cluster="mainnet-beta"
+>
+  View on Mainnet
+</TxnExplorerLink>
+
+// Devnet transaction
+
+<TxnExplorerLink
+  signature="2B5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM"
+  cluster="devnet"
+>
+  View on Devnet
+</TxnExplorerLink>
+
+// Testnet transaction
+
+<TxnExplorerLink
+  signature="3C6VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM"
+  cluster="testnet"
+>
+  View on Testnet
+</TxnExplorerLink>
+```
+
+### Different Button Variants
+
+```tsx
+// Default variant
+
+<TxnExplorerLink signature="abc123..." variant="default">
+  Default Style
+</TxnExplorerLink>
+
+// Outline variant (default)
+
+<TxnExplorerLink signature="abc123..." variant="outline">
+  Outline Style
+</TxnExplorerLink>
+
+// Ghost variant
+
+<TxnExplorerLink signature="abc123..." variant="ghost">
+  Ghost Style
+</TxnExplorerLink>
+
+// Link variant
+
+<TxnExplorerLink signature="abc123..." variant="link">
+  Link Style
+</TxnExplorerLink>
+```
+
+### Different Sizes
+
+```tsx
+// Small size
+
+<TxnExplorerLink signature="abc123..." size="sm">
+  Small Link
+</TxnExplorerLink>
+
+// Default size
+
+<TxnExplorerLink signature="abc123..." size="default">
+  Default Link
+</TxnExplorerLink>
+
+// Large size
+
+<TxnExplorerLink signature="abc123..." size="lg">
+  Large Link
+</TxnExplorerLink>
+
+// Icon only
+
+<TxnExplorerLink signature="abc123..." size="icon">
+  🔗
+</TxnExplorerLink>
+```
+
+### Custom Content
+
+```tsx
+// Custom text
+
+<TxnExplorerLink signature="abc123...">View Transaction Details</TxnExplorerLink>
+
+// Without icon
+
+<TxnExplorerLink signature="abc123..." showIcon={false}>
+  Check on Explorer
+</TxnExplorerLink>
+
+// With truncated signature
+
+<TxnExplorerLink signature="abc123...">
+  {signature.slice(0, 8)}...{signature.slice(-8)}
+</TxnExplorerLink>
+
+// Custom styling
+
+<TxnExplorerLink
+  signature="abc123..."
+  className="bg-blue-500 hover:bg-blue-600 text-white"
+>
+  Custom Styled Link
+</TxnExplorerLink>
+
+```
+
+## Explorer Features
+
+When users click the explorer link, they can see:
+
+### Transaction Details
+
+- Transaction signature and status
+- Block confirmation details
+- Fee information and compute units used
+- Timestamp and slot number
+
+### Account Changes
+
+- Balance changes for all involved accounts
+- Token transfers and amounts
+- Account modifications and updates
+- Program interactions and calls
+
+### Program Logs
+
+- Instruction execution logs
+- Error messages and debugging info
+- Program outputs and return values
+- Custom program log messages
+
+### Additional Information
+
+- Transaction size and priority fee
+- Recent blockhash used
+- Signer accounts and permissions
+- Cross-program invocations
+
+## Customization
+
+### Custom URL Generation
+
+```tsx
+const getCustomExplorerUrl = (signature: string, cluster: string) => {
+  // Use different explorer based on preference
+  const explorers = {
+    solana: `https://explorer.solana.com/tx/${signature}${
+      cluster !== "mainnet-beta" ? `?cluster=${cluster}` : ""
+    }`,
+    solscan: `https://solscan.io/tx/${signature}${
+      cluster !== "mainnet-beta" ? `?cluster=${cluster}` : ""
+    }`,
+    xray: `https://xray.helius.xyz/tx/${signature}${
+      cluster !== "mainnet-beta" ? `?network=${cluster}` : ""
+    }`,
+  };
+
+  return explorers.solana; // or based on user preference
+};
+```
+
+### Custom Styling
+
+```tsx
+<TxnExplorerLink
+  signature="abc123..."
+  className="bg-gradient-to-r from-purple-500 to-blue-500 hover:from-purple-600 hover:to-blue-600 text-white border-0"
+  size="lg"
+>
+  🔍 Explore Transaction
+</TxnExplorerLink>
+```

--- a/content/docs/onchainkit/Txn-Feedback/txn-explorer-link.mdx
+++ b/content/docs/onchainkit/Txn-Feedback/txn-explorer-link.mdx
@@ -4,15 +4,96 @@ description: Direct links to Solana Explorer for transaction details
 icon: ExternalLink
 ---
 
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+
 <PreviewComponent
   name={"Transaction Explorer Link"}
   v0JsonFileName={"txn-explorer-link"}
 >
-  <TxnExplorerLink
-    signature="5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM7n"
-    size="lg"
-    variant="secondary"
-  />
+  <div className="container mx-auto p-6 max-w-6xl bg-background text-foreground">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <Card className="bg-background text-foreground">
+        <CardHeader>
+          <CardTitle>Different Clusters</CardTitle>
+          <CardDescription className="text-muted-foreground">
+            Links to different Solana network clusters
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {["mainnet", "testnet", "devnet"].map((cluster) => (
+            <div key={cluster} className="space-y-2">
+              <h4 className="font-medium capitalize">{cluster}</h4>
+              <TxnExplorerLink
+                signature={{
+                  mainnet:
+                    "5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM7n",
+                  testnet:
+                    "2B5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM",
+                  devnet:
+                    "3C6VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM",
+                }[cluster]}
+                cluster={cluster === "mainnet" ? "mainnet-beta" : cluster}
+                className="w-full"
+              />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="bg-background text-foreground">
+        <CardHeader>
+          <CardTitle>Different Variants</CardTitle>
+          <CardDescription className="text-muted-foreground">
+            Various button styles and sizes
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {["default", "outline", "ghost", "link"].map((variant) => (
+            <div key={variant} className="space-y-2">
+              <h4 className="font-medium capitalize">{variant} Variant</h4>
+              <TxnExplorerLink
+                signature="5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM7n"
+                variant={variant}
+                className="w-full"
+              />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+
+    <Card className="mt-8 bg-background text-foreground">
+      <CardHeader>
+        <CardTitle>Different Sizes</CardTitle>
+        <CardDescription className="text-muted-foreground">
+          Various button sizes for different use cases
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {["sm", "default", "lg", "icon"].map((size) => (
+            <div key={size} className="space-y-2">
+              <h4 className="font-medium text-sm capitalize">{size}</h4>
+              <TxnExplorerLink
+                signature="5VfYmGC9L8ty3D4HutfxndoKXGBwXJWKKvxgF7qQzqK8xMjU9v7Rw2sP3nT6hL4jK9mN8bC1dF2eG3hI5jK6lM7n"
+                size={size}
+                className="w-full"
+              >
+                {size === "icon" ? "🔗" : undefined}
+              </TxnExplorerLink>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+
+  </div>
 </PreviewComponent>
 
 ## Installation

--- a/content/docs/onchainkit/meta.json
+++ b/content/docs/onchainkit/meta.json
@@ -31,6 +31,7 @@
     "Metaplex",
     "Meteora-DBC",
     "ZK-Compression",
-    "Jupiter-Recurring"
+    "Jupiter-Recurring",
+    "Txn-Feedback"
   ]
 }

--- a/public/r/txn-explorer-link.json
+++ b/public/r/txn-explorer-link.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "txn-explorer-link",
+  "type": "registry:block",
+  "title": "A link to open a transaction on Solana Explorer.",
+  "dependencies": [],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx",
+      "content": "\"use client\";\r\n\r\nimport type React from \"react\";\r\nimport { ExternalLink } from \"lucide-react\";\r\nimport { Button } from \"@/components/ui/button\";\r\nimport { cn } from \"@/lib/utils\";\r\n\r\ninterface TxnExplorerLinkProps {\r\n  signature: string;\r\n  cluster?: \"mainnet-beta\" | \"testnet\" | \"devnet\";\r\n  children?: React.ReactNode;\r\n  className?: string;\r\n  variant?:\r\n    | \"default\"\r\n    | \"destructive\"\r\n    | \"outline\"\r\n    | \"secondary\"\r\n    | \"ghost\"\r\n    | \"link\";\r\n  size?: \"default\" | \"sm\" | \"lg\" | \"icon\";\r\n  showIcon?: boolean;\r\n}\r\n\r\nexport function TxnExplorerLink({\r\n  signature,\r\n  cluster = \"mainnet-beta\",\r\n  children,\r\n  className,\r\n  variant = \"outline\",\r\n  size = \"sm\",\r\n  showIcon = true,\r\n}: TxnExplorerLinkProps) {\r\n  const getExplorerUrl = () => {\r\n    const baseUrl = \"https://explorer.solana.com/tx\";\r\n    const clusterParam =\r\n      cluster !== \"mainnet-beta\" ? `?cluster=${cluster}` : \"\";\r\n    return `${baseUrl}/${signature}${clusterParam}`;\r\n  };\r\n\r\n  const handleClick = () => {\r\n    window.open(getExplorerUrl(), \"_blank\", \"noopener,noreferrer\");\r\n  };\r\n\r\n  return (\r\n    <Button\r\n      onClick={handleClick}\r\n      variant={variant}\r\n      size={size}\r\n      className={cn(\"cursor-pointer hover:underline\", className)}\r\n    >\r\n      {children || (\r\n        <>\r\n          View on Explorer\r\n          {showIcon && (\r\n            <ExternalLink className=\"w-4 h-4 ml-2 text-muted-foreground\" />\r\n          )}\r\n        </>\r\n      )}\r\n    </Button>\r\n  );\r\n}\r\n",
+      "type": "registry:file",
+      "target": "components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx"
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -1387,6 +1387,20 @@
       ]
     },
     {
+      "name": "txn-explorer-link",
+      "type": "registry:block",
+      "title": "A link to open a transaction on Solana Explorer.",
+      "registryDependencies": [],
+      "dependencies": [],
+      "files": [
+        {
+          "path": "components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx",
+          "type": "registry:file",
+          "target": "components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx"
+        }
+      ]
+    },
+    {
       "name": "txn-list",
       "type": "registry:block",
       "title": "The TxnList component is a table of transactions with metadata.",

--- a/registry/components/txn-explorer-link.json
+++ b/registry/components/txn-explorer-link.json
@@ -1,0 +1,14 @@
+{
+  "name": "txn-explorer-link",
+  "type": "registry:block",
+  "title": "A link to open a transaction on Solana Explorer.",
+  "registryDependencies": [],
+  "dependencies": [],
+  "files": [
+    {
+      "path": "components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx",
+      "type": "registry:file",
+      "target": "components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new reusable UI component for linking directly to Solana transaction details on the Solana Explorer. The `TxnExplorerLink` button is now available for use, and the documentation and registry have been updated to support and showcase this component.

**New Component Addition**

* Added `TxnExplorerLink` React component in `components/ui/murphy/Txn-Feedback/txn-explorer-link.tsx`, providing a customizable button that opens a transaction on Solana Explorer in a new tab. It supports cluster selection, button variants, sizes, icons, and custom content.

**Documentation and Registry Integration**

* Created a comprehensive documentation page at `content/docs/onchainkit/Txn-Feedback/txn-explorer-link.mdx` with usage examples, props table, customization guides, and explorer feature explanations.
* Registered the new block in `public/r/txn-explorer-link.json`, `registry/components/txn-explorer-link.json`, and added it to the main registry in `registry.json` for discoverability and installation. [[1]](diffhunk://#diff-66d0b39929c17c03602f199c047fd735531690bae373fb44ac3f25dfee47387fR1-R16) [[2]](diffhunk://#diff-867b1bb48e704b59112d74f0e093797b22d086292fb815f6b0b7f60d468206f7R1-R14) [[3]](diffhunk://#diff-c1ccab6b761f7c3ef53302c329215f605bb24c73aa16fb75bc4da712926e972bR1389-R1402)
* Updated the meta documentation index in `content/docs/onchainkit/meta.json` to include the new "Txn-Feedback" section.

**Exports and Imports**

* Exported `TxnExplorerLink` from the Murphy UI index (`components/ui/murphy/index.tsx`) for easy import throughout the codebase. [[1]](diffhunk://#diff-65b40a1424040a8b9ee3b93205f44974691b824cec5b910af063ef65ed879ebfR40) [[2]](diffhunk://#diff-65b40a1424040a8b9ee3b93205f44974691b824cec5b910af063ef65ed879ebfL81-R83)

These changes make it simple for developers to add direct Solana Explorer links for transaction feedback in their applications.